### PR TITLE
feat: add configuration options to CLI and API

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,0 +1,28 @@
+name: test-pr
+run-name: Running tests for ${{ github.ref }}
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: ./.nvmrc
+                  cache: npm
+
+            - name: Install NPM Packages
+              run: npm ci
+
+            - name: Generate Test Data
+              run: npm run test:generate-data
+
+            - name: Run Tests
+              run: npm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## Running the App
 
-Use `npm run start` or any of the other start commands to run the CLI (see [CLI section of the README](./README.md#cli)).
+Use `npm run start` or any of the other start commands to run the CLI (see [CLI section of the README](./README.md#cli)). To pass arguments to the CLI, double escape them with `--`, e.g. `npm run start -- -- -j`.
 
 ## Running Tests
 
-First, you have to generate the coverage reports for testing using `npm run test:generate-data`.
-Afterwards you can run the tests proper by using `npm run test` or any of the other test commands like `npm run test:debug`.
+First, generate the coverage reports for testing using `npm run test:generate-data`.
+Afterwards run the tests proper by using `npm run test` or any of the other test commands like `npm run test:debug`.
 
 See also [test-data/README.md](test-data/README.md).

--- a/README.md
+++ b/README.md
@@ -44,11 +44,9 @@ const report: CrapReport = await getCrapReport({
 To use the library API in a CommonJS project, you will need to use dynamic `import` statements as this is a ESM library:
 
 ```ts
-import type { CrapReport } from "crap-score";
-
 async function main() {
     const { getCrapReport } = await import("crap-score");
-    const report: CrapReport = await getCrapReport({
+    const report = await getCrapReport({
         testCoverage: "./coverage/coverage-final.json",
     });
 }
@@ -57,11 +55,9 @@ async function main() {
 If you are using TypeScript, make sure to have `"moduleResolution": "node16"` to avoid `import` being transformed into `require`. If that is not an option, you can work around it via `eval`:
 
 ```ts
-import type { CrapReport } from "crap-score";
-
 async function main() {
     const { getCrapReport } = await eval("import('crap-score')");
-    const report: CrapReport = await getCrapReport({
+    const report = await getCrapReport({
         testCoverage: "./coverage/coverage-final.json",
     });
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CRAP Score
 
-Calculate and visualise the CRAP score of a JS/TS project using the provided API or CLI.
+Calculate and visualize the CRAP score of a JS/TS project using the provided API or CLI.
 
 ## Example
 
@@ -21,7 +21,11 @@ Combining complexity and coverage information, the CRAP score gives you insight 
 ### CLI
 
 Install the package (or use it directly via npx), then just run `npx crap <path-to-coverage>`.
-The command expects an istanbul JSON coverage report as input and generates both an HTML and a JSON report in the `crap-report` folder, containing the CRAP score of each function in the original istanbul report.
+The command expects an istanbul JSON coverage report as input (see [JSON Coverage Report](#istanbul-json-coverage-report)) and generates both an HTML and a JSON report in the `crap-report` folder, containing the CRAP score of each function in the original istanbul report.
+
+```sh
+crap --help
+```
 
 ### API
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "crap-score",
     "version": "1.0.0",
-    "description": "Calculate and visualise the CRAP score of a JS/TS project using the provided API or CLI.",
+    "description": "Calculate and visualize the CRAP score of a JS/TS project using the provided API or CLI.",
     "license": "MIT",
     "keywords": [
         "CRAP Score",

--- a/src/command/compute-crap.command.ts
+++ b/src/command/compute-crap.command.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@nestjs/common";
-import { CommandRunner, InquirerService, Option, RootCommand } from "nest-commander";
+import { CommandRunner, Help, InquirerService, Option, RootCommand } from "nest-commander";
 import { ConfigService } from "../crap/config.service.js";
 import { CrapReportService } from "../crap/crap-report.service.js";
 import { FileSystemService } from "../crap/file-system.service.js";
@@ -7,6 +7,7 @@ import { HtmlReportService } from "../crap/html-report/html-report.service.js";
 
 @RootCommand({
     arguments: "[testCoveragePath]",
+    description: "Calculate and visualize the CRAP score of a JS/TS project.",
 })
 export class ComputeCrapCommand extends CommandRunner {
     public constructor(
@@ -55,6 +56,26 @@ export class ComputeCrapCommand extends CommandRunner {
     })
     public parseHtmlReportDir(htmlReportDir: string): string {
         return htmlReportDir;
+    }
+
+    @Option({
+        flags: "-h, --help",
+        description: "Display this help message.",
+    })
+    public helpMessage(): void {
+        this.command.help();
+    }
+
+    @Help("afterAll")
+    public helpMessageExamples(): string {
+        return [
+            "",
+            "Examples:",
+            "  crap --html",
+            "  crap --html -- ./coverage/coverage-final.json        # use `--` to separate options from arguments when not passing a value to `--html`",
+            "  crap --html ./html/ ./coverage/coverage-final.json",
+            "  crap --html=./html/ ./coverage/coverage-final.json",
+        ].join("\n");
     }
 
     private processOptions(options: { json?: string | true; html?: string | true }): void {

--- a/src/command/compute-crap.command.ts
+++ b/src/command/compute-crap.command.ts
@@ -1,4 +1,5 @@
-import { CommandRunner, InquirerService, RootCommand } from "nest-commander";
+import { Logger } from "@nestjs/common";
+import { CommandRunner, InquirerService, Option, RootCommand } from "nest-commander";
 import { ConfigService } from "../crap/config.service.js";
 import { CrapReportService } from "../crap/crap-report.service.js";
 import { FileSystemService } from "../crap/file-system.service.js";
@@ -14,20 +15,58 @@ export class ComputeCrapCommand extends CommandRunner {
         private readonly fileSystemService: FileSystemService,
         private readonly htmlReportService: HtmlReportService,
         private readonly configService: ConfigService,
+        private readonly logger: Logger,
     ) {
         super();
     }
 
-    public async run(inputs: string[]): Promise<void> {
-        this.configService.config.jsonReportFile = "./crap-report/crap-report.json";
-        this.configService.config.htmlReportDir = "./crap-report/html/";
+    public async run(
+        inputs: string[],
+        options: {
+            json?: string | true;
+            html?: string | true;
+        },
+    ): Promise<void> {
+        this.processOptions(options);
 
         const testCoveragePath = await this.getTestCoveragePath(inputs);
         const coverageReport = await this.fileSystemService.loadCoverageReport(testCoveragePath);
 
         const result = await this.crapReportService.createReport({ testCoverage: coverageReport });
 
-        await this.htmlReportService.createReport(result);
+        if (this.configService.config.htmlReportDir) {
+            await this.htmlReportService.createReport(result);
+        }
+    }
+
+    @Option({
+        flags: "--json [jsonReportFile]",
+        description:
+            "Specifies file path where the JSON report will be written to. Defaults to './crap-report/crap-report.json'. If undefined, no JSON report is written.",
+    })
+    public parseJsonReportFile(jsonReportFile: string): string {
+        return jsonReportFile;
+    }
+
+    @Option({
+        flags: "--html [htmlReportDir]",
+        description:
+            "Specifies directory path where the HTML report will be written to. Defaults to './crap-report/html/'. If undefined, no HTML report is written.",
+    })
+    public parseHtmlReportDir(htmlReportDir: string): string {
+        return htmlReportDir;
+    }
+
+    private processOptions(options: { json?: string | true; html?: string | true }): void {
+        this.configService.config.jsonReportFile =
+            options.json === true ? "./crap-report/crap-report.json" : options.json;
+        this.configService.config.htmlReportDir = options.html === true ? "./crap-report/html/" : options.html;
+        if (
+            this.configService.config.jsonReportFile == undefined &&
+            this.configService.config.htmlReportDir == undefined
+        ) {
+            this.logger.warn("No report will be written. Use --json or --html to specify where to write the report.");
+        }
     }
 
     private async getTestCoveragePath(inputs: string[]): Promise<string> {

--- a/src/command/compute-crap.command.ts
+++ b/src/command/compute-crap.command.ts
@@ -3,7 +3,6 @@ import { CommandRunner, Help, InquirerService, Option, RootCommand } from "nest-
 import { ConfigService } from "../crap/config.service.js";
 import { CrapReportService } from "../crap/crap-report.service.js";
 import { FileSystemService } from "../crap/file-system.service.js";
-import { HtmlReportService } from "../crap/html-report/html-report.service.js";
 
 @RootCommand({
     arguments: "[testCoveragePath]",
@@ -14,7 +13,6 @@ export class ComputeCrapCommand extends CommandRunner {
         private readonly inquirer: InquirerService,
         private readonly crapReportService: CrapReportService,
         private readonly fileSystemService: FileSystemService,
-        private readonly htmlReportService: HtmlReportService,
         private readonly configService: ConfigService,
         private readonly logger: Logger,
     ) {
@@ -35,10 +33,6 @@ export class ComputeCrapCommand extends CommandRunner {
         const coverageReport = await this.fileSystemService.loadCoverageReport(testCoveragePath);
 
         const result = await this.crapReportService.createReport({ testCoverage: coverageReport });
-
-        if (this.configService.getHtmlReportDir()) {
-            await this.htmlReportService.createReport(result);
-        }
     }
 
     @Option({
@@ -97,6 +91,7 @@ export class ComputeCrapCommand extends CommandRunner {
             "Examples:",
             "  crap --html",
             "  crap --html -- ./coverage/coverage-final.json        # use `--` to separate options from coverage path when not passing a value to `--html`",
+            "  crap ./coverage/coverage-final.json --html",
             "  crap --html ./html/ ./coverage/coverage-final.json",
             "  crap --html=./html/ ./coverage/coverage-final.json",
         ].join("\n");

--- a/src/command/compute-crap.command.ts
+++ b/src/command/compute-crap.command.ts
@@ -102,7 +102,7 @@ export class ComputeCrapCommand extends CommandRunner {
         this.configService.setHtmlReportDir(options.html === true ? "./crap-report/html/" : options.html);
 
         if (options.verbosity != undefined) {
-            this.configService.setLogLevels(options.verbosity);
+            this.configService.setLogger(options.verbosity);
         }
 
         if (this.configService.getJsonReportFile() == undefined && this.configService.getHtmlReportDir() == undefined) {

--- a/src/crap.ts
+++ b/src/crap.ts
@@ -4,5 +4,5 @@ import { CommandFactory } from "nest-commander";
 import { AppModule } from "./app.module.js";
 
 await CommandFactory.run(AppModule, {
-    logger: ["error", "warn"],
+    logger: [],
 });

--- a/src/crap/complexity.service.ts
+++ b/src/crap/complexity.service.ts
@@ -58,8 +58,6 @@ export class ComplexityService {
      * @see https://eslint.org/docs/latest/integrate/nodejs-api#-eslintlinttextcode-options
      */
     public async getComplexity({ sourcePath }: { sourcePath: string }): Promise<Array<FunctionComplexity | null>> {
-        const { htmlReportDir } = this.configService.config;
-
         const source = await this.fileSystemService.loadSourceFile(sourcePath);
         const lines = source.split("\n");
         const [result] = await this.eslint.lintText(source);
@@ -111,7 +109,7 @@ export class ComplexityService {
                 type: messageData.messageId,
             };
 
-            if (htmlReportDir) {
+            if (this.configService.getHtmlReportDir()) {
                 result.sourceCode = lines.slice(messageData.line - 1, messageData.endLine).join("\n");
             }
 

--- a/src/crap/config.service.ts
+++ b/src/crap/config.service.ts
@@ -5,12 +5,12 @@ export interface Config {
      * Specifies path where the JSON report will be written to.
      * If undefined, no report is written to the disk.
      */
-    jsonReportFile?: string;
+    jsonReportFile?: string | undefined;
     /**
      * Specifies path where the HTML report will be written to.
      * If undefined, no report is written to the disk.
      */
-    htmlReportDir?: string;
+    htmlReportDir?: string | undefined;
 }
 
 @Injectable()

--- a/src/crap/config.service.ts
+++ b/src/crap/config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger, LogLevel } from "@nestjs/common";
 
 export interface Config {
     /**
@@ -11,9 +11,39 @@ export interface Config {
      * If undefined, no report is written to the disk.
      */
     htmlReportDir?: string | undefined;
+    /**
+     * Specifies log levels that should be logged. Defaults to `["error", "warn"]`.
+     * If empty, no logs are written.
+     */
+    logLevels: LogLevel[];
 }
 
 @Injectable()
 export class ConfigService {
-    public config: Config = {};
+    private readonly config: Config = { logLevels: [] };
+
+    public constructor() {
+        this.setLogLevels(["error", "warn"]);
+    }
+
+    public getJsonReportFile(): string | undefined {
+        return this.config.jsonReportFile;
+    }
+
+    public setJsonReportFile(jsonReportFile: string | undefined): void {
+        this.config.jsonReportFile = jsonReportFile;
+    }
+
+    public getHtmlReportDir(): string | undefined {
+        return this.config.htmlReportDir;
+    }
+
+    public setHtmlReportDir(htmlReportDir: string | undefined): void {
+        this.config.htmlReportDir = htmlReportDir;
+    }
+
+    public setLogLevels(logLevels: LogLevel[]): void {
+        this.config.logLevels = logLevels;
+        Logger.overrideLogger(logLevels);
+    }
 }

--- a/src/crap/config.service.ts
+++ b/src/crap/config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, LogLevel } from "@nestjs/common";
+import { Injectable, Logger, LoggerService, LogLevel } from "@nestjs/common";
 
 export interface Config {
     /**
@@ -11,25 +11,24 @@ export interface Config {
      * If undefined, no report is written to the disk.
      */
     htmlReportDir?: string | undefined;
-    /**
-     * Specifies log levels that should be logged. Defaults to `["error", "warn"]`.
-     * If empty, no logs are written.
-     */
-    logLevels: LogLevel[];
 }
 
 @Injectable()
 export class ConfigService {
-    private readonly config: Config = { logLevels: [] };
+    private readonly config: Config = {};
 
     public constructor() {
-        this.setLogLevels(["error", "warn"]);
+        this.setLogger(["error", "warn"]);
     }
 
     public getJsonReportFile(): string | undefined {
         return this.config.jsonReportFile;
     }
 
+    /**
+     * Specifies path where the JSON report will be written to.
+     * If undefined, no report is written to the disk.
+     */
     public setJsonReportFile(jsonReportFile: string | undefined): void {
         this.config.jsonReportFile = jsonReportFile;
     }
@@ -38,12 +37,21 @@ export class ConfigService {
         return this.config.htmlReportDir;
     }
 
+    /**
+     * Specifies path where the HTML report will be written to.
+     * If undefined, no report is written to the disk.
+     */
     public setHtmlReportDir(htmlReportDir: string | undefined): void {
         this.config.htmlReportDir = htmlReportDir;
     }
 
-    public setLogLevels(logLevels: LogLevel[]): void {
-        this.config.logLevels = logLevels;
-        Logger.overrideLogger(logLevels);
+    /**
+     * Specifies logger via log levels or a custom logger.
+     *
+     * If array, specifies log levels that should be logged. Defaults to `["error", "warn"]`.
+     * If empty, no logs are written.
+     */
+    public setLogger(log: LogLevel[] | LoggerService): void {
+        Logger.overrideLogger(log);
     }
 }

--- a/src/crap/crap-report.service.ts
+++ b/src/crap/crap-report.service.ts
@@ -19,7 +19,6 @@ export class CrapReportService {
     ) {}
 
     public async createReport({ testCoverage }: { testCoverage: CoverageMapData }): Promise<CrapReport> {
-        const { jsonReportFile } = this.configService.config;
         const result: CrapReport = {};
         const rootDir = this.getRootDir(Object.keys(testCoverage)) + "/";
 
@@ -32,6 +31,7 @@ export class CrapReportService {
             }),
         );
 
+        const jsonReportFile = this.configService.getJsonReportFile();
         if (jsonReportFile) {
             await this.fileSystemService.writeJsonReport(jsonReportFile, result);
         }

--- a/src/crap/crap-report.service.ts
+++ b/src/crap/crap-report.service.ts
@@ -1,16 +1,18 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { CoverageMapData, FileCoverageData, FunctionMapping } from "istanbul-lib-coverage";
-import { ComplexityService, FunctionComplexity } from "./complexity.service.js";
+import { CoverageMapData, FileCoverageData } from "istanbul-lib-coverage";
+import { ComplexityService } from "./complexity.service.js";
 import { ConfigService } from "./config.service.js";
 import { CrapFile, CrapReport } from "./crap-report.js";
 import { crap } from "./crap-score.js";
 import { FileSystemService } from "./file-system.service.js";
 import { getCoverageForFunction } from "./function-coverage.js";
+import { HtmlReportService } from "./html-report/html-report.service.js";
 import { LintService } from "./lint.service.js";
 
 @Injectable()
 export class CrapReportService {
     public constructor(
+        private readonly htmlReportService: HtmlReportService,
         private readonly complexityService: ComplexityService,
         private readonly lintService: LintService,
         private readonly fileSystemService: FileSystemService,
@@ -34,6 +36,10 @@ export class CrapReportService {
         const jsonReportFile = this.configService.getJsonReportFile();
         if (jsonReportFile) {
             await this.fileSystemService.writeJsonReport(jsonReportFile, result);
+        }
+
+        if (this.configService.getHtmlReportDir()) {
+            await this.htmlReportService.createReport(result);
         }
 
         return result;

--- a/src/crap/crap-report.ts
+++ b/src/crap/crap-report.ts
@@ -50,7 +50,7 @@ export interface CrapFunctionJsonObject {
 
 /**
  * A JSON serializable object containing a file's statistics.
- * 
+ *
  * Map containing all functions as reported by istanbul for a given file using the name reported by istanbul.
  */
 export interface CrapFileJsonObject {
@@ -62,7 +62,7 @@ export interface CrapFileJsonObject {
 
 /**
  * A JSON serializable object containing a project's statistics.
- * 
+ *
  * Map containing all files as reported by istanbul for a given project using the path reported by istanbul.
  */
 export interface CrapReportJsonObject {

--- a/src/crap/file-system.service.ts
+++ b/src/crap/file-system.service.ts
@@ -47,7 +47,7 @@ export class FileSystemService {
     private async loadFile({ path, type }: { path: string | URL; type: LoadedFile }): Promise<string> {
         try {
             const data = await readFile(path, "utf-8");
-            this.logger.log(`Loaded ${type} from "${path}".`);
+            this.logger.debug(`Loaded ${type} from "${path}".`);
             return data;
         } catch (error) {
             this.logger.error(`Failed to load ${type} from "${path}".`, { error });

--- a/src/crap/html-report/html-report.service.ts
+++ b/src/crap/html-report/html-report.service.ts
@@ -30,7 +30,7 @@ export class HtmlReportService {
     ) {}
 
     public async createReport(crapReport: CrapReport): Promise<void> {
-        const { htmlReportDir } = this.configService.config;
+        const htmlReportDir = this.configService.getHtmlReportDir();
         if (!htmlReportDir) {
             throw new Error("No HTML report directory specified.");
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export async function getCrapReport({
     htmlReportDir,
     logLevels,
 }: CrapReportOptions): Promise<CrapReport> {
-    const app = await NestFactory.create(CrapModule);
+    const app = await NestFactory.create(CrapModule, { logger: [] });
 
     const configService = app.get(ConfigService);
     configService.setJsonReportFile(jsonReportFile);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { LogLevel } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { CoverageMapData } from "istanbul-lib-coverage";
 import { ConfigService } from "./crap/config.service.js";
@@ -23,6 +24,11 @@ export interface CrapReportOptions {
      * If undefined, no report is written to the disk.
      */
     htmlReportDir?: string | undefined;
+    /**
+     * Specifies log levels that should be logged. Defaults to `["error", "warn"]`.
+     * If empty, no logs are written.
+     */
+    logLevels?: LogLevel[];
 }
 
 /**
@@ -34,12 +40,16 @@ export async function getCrapReport({
     testCoverage,
     jsonReportFile,
     htmlReportDir,
+    logLevels,
 }: CrapReportOptions): Promise<CrapReport> {
     const app = await NestFactory.create(CrapModule);
 
     const configService = app.get(ConfigService);
-    configService.config.jsonReportFile = jsonReportFile;
-    configService.config.htmlReportDir = htmlReportDir;
+    configService.setJsonReportFile(jsonReportFile);
+    configService.setHtmlReportDir(htmlReportDir);
+    if (logLevels) {
+        configService.setLogLevels(logLevels);
+    }
 
     let coverageReport: CoverageMapData;
     if (typeof testCoverage === "string" || testCoverage instanceof URL) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from "@nestjs/common";
+import { LoggerService, LogLevel } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { CoverageMapData } from "istanbul-lib-coverage";
 import { ConfigService } from "./crap/config.service.js";
@@ -28,7 +28,7 @@ export interface CrapReportOptions {
      * Specifies log levels that should be logged. Defaults to `["error", "warn"]`.
      * If empty, no logs are written.
      */
-    logLevels?: LogLevel[];
+    log?: LogLevel[] | LoggerService;
 }
 
 /**
@@ -40,15 +40,15 @@ export async function getCrapReport({
     testCoverage,
     jsonReportFile,
     htmlReportDir,
-    logLevels,
+    log,
 }: CrapReportOptions): Promise<CrapReport> {
     const app = await NestFactory.create(CrapModule, { logger: [] });
 
     const configService = app.get(ConfigService);
     configService.setJsonReportFile(jsonReportFile);
     configService.setHtmlReportDir(htmlReportDir);
-    if (logLevels) {
-        configService.setLogLevels(logLevels);
+    if (log) {
+        configService.setLogger(log);
     }
 
     let coverageReport: CoverageMapData;

--- a/test-data/cjs/src/class.ts
+++ b/test-data/cjs/src/class.ts
@@ -23,5 +23,4 @@ const ClassExpression = class {
     };
 };
 
-
 export default MyClass;


### PR DESCRIPTION
Allow to configure the following:

- whether to write a JSON report and where
- whether to write an HTML report and where
- log level