### PR TITLE
fix: inferred type cannot be named without a reference

### DIFF
--- a/src/crap/complexity.service.ts
+++ b/src/crap/complexity.service.ts
@@ -136,7 +136,7 @@ export class ComplexityService {
                 },
             },
             plugins: {
-                crap: crapPlugin as unknown as ESLint.Plugin,
+                crap: crapPlugin,
             },
         });
     }

--- a/src/eslint-plugin-crap/complexity.ts
+++ b/src/eslint-plugin-crap/complexity.ts
@@ -1,134 +1,136 @@
 /**
  * Based on `complexity` rule from ESLint, but modified for this project.
  *
- * @see https://github.com/eslint/eslint/blob/v8.36.0/lib/rules/complexity.js
+ * @see https://github.com/eslint/eslint/blob/v8.47.0/lib/rules/complexity.js
  */
 
 import { ASTUtils, ESLintUtils } from "@typescript-eslint/utils";
+import { RuleListener, RuleModule } from "@typescript-eslint/utils/ts-eslint";
 
 function isLogicalAssignmentOperator(operator: string): boolean {
     return ["&&=", "||=", "??="].includes(operator);
 }
 
-export const complexityRule = ESLintUtils.RuleCreator.withoutDocs({
-    meta: {
-        type: "suggestion",
-        schema: [],
-        messages: {
-            function: "{{name}} has a complexity of {{complexity}}.",
-            enum: "Found TypeScript Enum {{name}}.",
-            export: "Found export statement.",
-            class: "Found Class {{name}}.",
+export const complexityRule: RuleModule<"function" | "enum" | "export" | "class", never[], RuleListener> =
+    ESLintUtils.RuleCreator.withoutDocs({
+        meta: {
+            type: "suggestion",
+            schema: [],
+            messages: {
+                function: "{{name}} has a complexity of {{complexity}}.",
+                enum: "Found TypeScript Enum {{name}}.",
+                export: "Found export statement.",
+                class: "Found Class {{name}}.",
+            },
         },
-    },
-    defaultOptions: [],
-    create(context) {
-        // Using a stack to store complexity per code path
-        const complexities: number[] = [];
+        defaultOptions: [],
+        create(context) {
+            // Using a stack to store complexity per code path
+            const complexities: number[] = [];
 
-        function increaseComplexity(): void {
-            complexities[complexities.length - 1]++;
-        }
+            function increaseComplexity(): void {
+                complexities[complexities.length - 1]++;
+            }
 
-        return {
-            onCodePathStart() {
-                // The initial complexity is 1, representing one execution path in the CodePath
-                complexities.push(1);
-            },
+            return {
+                onCodePathStart() {
+                    // The initial complexity is 1, representing one execution path in the CodePath
+                    complexities.push(1);
+                },
 
-            // Each branching in the code adds 1 to the complexity
-            CatchClause: increaseComplexity,
-            ConditionalExpression: increaseComplexity,
-            LogicalExpression: increaseComplexity,
-            ForStatement: increaseComplexity,
-            ForInStatement: increaseComplexity,
-            ForOfStatement: increaseComplexity,
-            IfStatement: increaseComplexity,
-            WhileStatement: increaseComplexity,
-            DoWhileStatement: increaseComplexity,
+                // Each branching in the code adds 1 to the complexity
+                CatchClause: increaseComplexity,
+                ConditionalExpression: increaseComplexity,
+                LogicalExpression: increaseComplexity,
+                ForStatement: increaseComplexity,
+                ForInStatement: increaseComplexity,
+                ForOfStatement: increaseComplexity,
+                IfStatement: increaseComplexity,
+                WhileStatement: increaseComplexity,
+                DoWhileStatement: increaseComplexity,
 
-            // Avoid `default`
-            "SwitchCase[test]": increaseComplexity,
+                // Avoid `default`
+                "SwitchCase[test]": increaseComplexity,
 
-            // Logical assignment operators have short-circuiting behavior
-            AssignmentExpression(node) {
-                if (isLogicalAssignmentOperator(node.operator)) {
-                    increaseComplexity();
-                }
-            },
+                // Logical assignment operators have short-circuiting behavior
+                AssignmentExpression(node) {
+                    if (isLogicalAssignmentOperator(node.operator)) {
+                        increaseComplexity();
+                    }
+                },
 
-            onCodePathEnd: ((codePath: any, node: any) => {
-                const complexity = complexities.pop()!;
+                onCodePathEnd: ((codePath: any, node: any) => {
+                    const complexity = complexities.pop()!;
 
-                /*
-                 * This rule only evaluates complexity of functions, so "program" is excluded.
-                 */
-                if (codePath.origin !== "function") {
-                    return;
-                }
+                    /*
+                     * This rule only evaluates complexity of functions, so "program" is excluded.
+                     */
+                    if (codePath.origin !== "function") {
+                        return;
+                    }
 
-                context.report({
-                    node,
-                    messageId: "function",
-                    data: {
-                        name: ASTUtils.getFunctionNameWithKind(node),
-                        complexity,
-                    },
-                });
-            }) as any, // onCodePathEnd is not typed in @typescript-eslint/utils, neither is CodePath
+                    context.report({
+                        node,
+                        messageId: "function",
+                        data: {
+                            name: ASTUtils.getFunctionNameWithKind(node),
+                            complexity,
+                        },
+                    });
+                }) as any, // onCodePathEnd is not typed in @typescript-eslint/utils, neither is CodePath
 
-            // report enums, so that we can match them against the coverage data
-            TSEnumDeclaration: (node) => {
-                context.report({
-                    node,
-                    messageId: "enum",
-                    data: {
-                        name: `enum '${node.id.name}'`,
-                    },
-                });
-            },
+                // report enums, so that we can match them against the coverage data
+                TSEnumDeclaration: (node) => {
+                    context.report({
+                        node,
+                        messageId: "enum",
+                        data: {
+                            name: `enum '${node.id.name}'`,
+                        },
+                    });
+                },
 
-            // report classes, so that we can match them against the coverage data
-            ClassDeclaration: (node) => {
-                const name = node.id ? `class '${node.id.name}'` : "anonymous class";
-                context.report({
-                    node,
-                    messageId: "class",
-                    data: {
-                        name,
-                    },
-                });
-            },
-            ClassExpression: (node) => {
-                const name = node.id ? `class '${node.id.name}'` : "anonymous class";
-                context.report({
-                    node,
-                    messageId: "class",
-                    data: {
-                        name,
-                    },
-                });
-            },
+                // report classes, so that we can match them against the coverage data
+                ClassDeclaration: (node) => {
+                    const name = node.id ? `class '${node.id.name}'` : "anonymous class";
+                    context.report({
+                        node,
+                        messageId: "class",
+                        data: {
+                            name,
+                        },
+                    });
+                },
+                ClassExpression: (node) => {
+                    const name = node.id ? `class '${node.id.name}'` : "anonymous class";
+                    context.report({
+                        node,
+                        messageId: "class",
+                        data: {
+                            name,
+                        },
+                    });
+                },
 
-            // report exports, so that we can match them against the coverage data
-            ExportAllDeclaration: (node) => {
-                context.report({
-                    node,
-                    messageId: "export",
-                });
-            },
-            ExportDefaultDeclaration: (node) => {
-                context.report({
-                    node,
-                    messageId: "export",
-                });
-            },
-            ExportNamedDeclaration: (node) => {
-                context.report({
-                    node,
-                    messageId: "export",
-                });
-            },
-        };
-    },
-});
+                // report exports, so that we can match them against the coverage data
+                ExportAllDeclaration: (node) => {
+                    context.report({
+                        node,
+                        messageId: "export",
+                    });
+                },
+                ExportDefaultDeclaration: (node) => {
+                    context.report({
+                        node,
+                        messageId: "export",
+                    });
+                },
+                ExportNamedDeclaration: (node) => {
+                    context.report({
+                        node,
+                        messageId: "export",
+                    });
+                },
+            };
+        },
+    });

--- a/src/eslint-plugin-crap/index.ts
+++ b/src/eslint-plugin-crap/index.ts
@@ -1,7 +1,8 @@
+import { ESLint, Rule } from "eslint";
 import { complexityRule } from "./complexity.js";
 
-export const crapPlugin = {
+export const crapPlugin: ESLint.Plugin = {
     rules: {
-        complexity: complexityRule,
+        complexity: complexityRule as unknown as Rule.RuleModule,
     },
 };


### PR DESCRIPTION
Add explicit type annotations to fix errors of the form

> The inferred type of 'foo' cannot be named without a reference to 'path'. This is likely not portable. A type annotation is necessary.

See also this failed run: https://github.com/ahilke/js-crap-score/actions/runs/5835167967