### PR TITLE
chore: upgrade all github actions

### DIFF
--- a/.github/workflows/publish-crap-report.yaml
+++ b/.github/workflows/publish-crap-report.yaml
@@ -10,10 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version-file: ./.nvmrc
                   cache: npm
@@ -31,7 +31,7 @@ jobs:
               run: npm run start -- -- ./coverage/coverage-final.json --html
 
             - name: Upload Pages Artifact
-              uses: actions/upload-pages-artifact@v1
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: ./crap-report/html
     deploy:
@@ -51,4 +51,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v1
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -16,10 +16,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   registry-url: https://registry.npmjs.org
                   node-version-file: ./.nvmrc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version-file: ./.nvmrc
                   cache: npm
@@ -33,7 +33,7 @@ jobs:
               run: npm run test:generate-data
 
             - name: Run Tests & Publish Coverage to Code Climate
-              uses: paambaati/codeclimate-action@v5.0.0
+              uses: paambaati/codeclimate-action@v8
               env:
                   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
               if: ${{ env.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
Update github actions to address deprecation warnings for node 16

<img width="1440" alt="Screenshot 2024-06-22 at 12 14 10" src="https://github.com/ahilke/js-crap-score/assets/12299348/28eae9ea-2245-49ff-bfb3-f2d149250fcf">
