### PR TITLE
chore: remove Code Climate integration

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -8,8 +8,6 @@ on:
 jobs:
     test:
         uses: ./.github/workflows/test.yaml
-        secrets:
-            CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
     npm-publish:
         needs: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,10 +8,6 @@ on:
         branches:
             - main
     workflow_call:
-        secrets:
-            CC_TEST_REPORTER_ID:
-                description: "Code Climate Test Reporter ID to publish test results to Code Climate."
-                required: true
 
 jobs:
     test:
@@ -32,10 +28,5 @@ jobs:
             - name: Generate Test Data
               run: npm run test:generate-data
 
-            - name: Run Tests & Publish Coverage to Code Climate
-              uses: paambaati/codeclimate-action@v8
-              env:
-                  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-              if: ${{ env.CC_TEST_REPORTER_ID }}
-              with:
-                  coverageCommand: npm run test:cov
+            - name: Run Tests
+              run: npm run test:cov

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,6 @@ const config = {
     collectCoverageFrom: ["src/**/*.ts"],
     coveragePathIgnorePatterns: ["__tests__/"],
     coverageDirectory: "./coverage",
-    // "lcov" is required for Code Climate, "json" and "html" are purely informational
     coverageReporters: ["lcov", "json", "html"],
 } satisfies JestConfigWithTsJest;
 


### PR DESCRIPTION
# Summary

Code Climate integration has been discontinued. References:

- https://github.com/paambaati/codeclimate-action
- https://docs.qlty.sh/migration/coverage
- https://codeclimate.com/blog/code-climate-quality-is-now-qlty-software 

The value it added was limited, so removed without migration or replacement. Test coverage is still available for local development.